### PR TITLE
Rubocop upgrade redux

### DIFF
--- a/.rubocop_schema.yml
+++ b/.rubocop_schema.yml
@@ -2,7 +2,7 @@ Style/NumericLiterals:
   Exclude:
     - 'db/schema.rb'
 
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: true
 
 Metrics/BlockNesting:

--- a/fix-db-schema-conflicts.gemspec
+++ b/fix-db-schema-conflicts.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_dependency "rubocop", "~> 0.36.0"
+  spec.add_dependency "rubocop", ">= 0.36.0"
 end

--- a/lib/fix_db_schema_conflicts/tasks/db.rake
+++ b/lib/fix_db_schema_conflicts/tasks/db.rake
@@ -8,7 +8,7 @@ namespace :db do
         "#{Rails.root}/db/schema.rb"
       end
       rubocop_yml = File.expand_path('../../../../.rubocop_schema.yml', __FILE__)
-      `rubocop --auto-correct --config #{rubocop_yml} #{filename}`
+      `bundle exec rubocop --auto-correct --config #{rubocop_yml} #{filename}`
       `sed -E -e 's/, +/, /g' #{filename} > db/schema.fixed.rb`
       `mv db/schema.fixed.rb #{filename}`
     end


### PR DESCRIPTION
1. Relaxes version dependency on Rubocop to `>= 0.36`
1. Renames a cop renamed in Rubocop v 0.36