### PR TITLE
Fix for projects with spaces in path

### DIFF
--- a/lib/fix_db_schema_conflicts/tasks/db.rake
+++ b/lib/fix_db_schema_conflicts/tasks/db.rake
@@ -8,7 +8,7 @@ namespace :db do
         "#{Rails.root}/db/schema.rb"
       end
       rubocop_yml = File.expand_path('../../../../.rubocop_schema.yml', __FILE__)
-      `bundle exec rubocop --auto-correct --config #{rubocop_yml} #{filename}`
+      `bundle exec rubocop --auto-correct --config #{rubocop_yml} '#{filename}'`
     end
   end
 end


### PR DESCRIPTION
For instance, ~/Active Projects/my-rails-app should work correctly now.