### PR TITLE
Fix tests for latest rubocop

### DIFF
--- a/.rubocop_schema.yml
+++ b/.rubocop_schema.yml
@@ -5,8 +5,7 @@ Style/ExtraSpacing:
   AllowForAlignment: false
 
 Style/NumericLiterals:
-  Exclude:
-    - 'db/schema.rb'
+  Enabled: false
 
 Style/SpaceBeforeFirstArg:
   Enabled: true

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -21,6 +21,7 @@ end
 def reference_db_schema
   <<-RUBY
 # encoding: UTF-8
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/spec/test-app/db/schema.rb
+++ b/spec/test-app/db/schema.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.


### PR DESCRIPTION
- Adds space after encoding line to appease the `Style/EmptyLineAfterMagicComment` cop (added in `0.48`)
- Explicitly disable `Style/NumericLiterals`, the exclude was not working.