### PR TITLE
Disable the Style/WordArray cop.

### DIFF
--- a/.rubocop_schema.yml
+++ b/.rubocop_schema.yml
@@ -18,7 +18,7 @@ Style/AlignHash:
   EnforcedHashRocketStyle: 'key'
 
 Style/WordArray:
-  MinSize: 3
+  Enabled: false
 
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: 'comma'


### PR DESCRIPTION
I prefer uniform `add_index` formatting. The `Style/WordArray` cop introduces an inconsistency.

With the current `.rubocop_schema.yml` my `db/schema.rb` is formatted as:

````
add_index "invoices", %w(site_id invoiced_at synch), name: "index_invoices_for_accounting_sync", using: :btree
add_index "invoices", ["uuid"], name: "index_invoices_on_uuid", unique: true, using: :btree
````

While I prefer consistent bracket formatting for multicolumn indexes:

````
add_index "invoices", ["site_id", "invoiced_at", "synch"], name: "index_invoices_for_accounting_sync", using: :btree
add_index "invoices", ["uuid"], name: "index_invoices_on_uuid", unique: true, using: :btree
````

I'd like to disable the `Style/WordArray` cop.

An alternate solution is to add the capability to specify a local `.rubocop_schema.yml` that the `db:schema:dump` rake task uses instead of the configuration file supplied by the gem.

Note: the simpler solution of disabling the `Style/WordArray` cop is all I need.