### PR TITLE
Support rubocop >= 0.49.0

### DIFF
--- a/.rubocop_schema.49.yml
+++ b/.rubocop_schema.49.yml
@@ -1,23 +1,23 @@
-# Configuration for Rubocop >= 0.38.0, < 0.49.0
+# Configuration for Rubocop >= 0.49.0
 
-Style/ExtraSpacing:
+Layout/AlignHash:
+  EnforcedColonStyle: 'key'
+  EnforcedHashRocketStyle: 'key'
+
+Layout/ExtraSpacing:
   # When true, allows most uses of extra spacing if the intent is to align
   # things with the previous or next line, not counting empty lines or comment
   # lines.
   AllowForAlignment: false
 
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
 Style/NumericLiterals:
   Enabled: false
 
-Style/SpaceBeforeFirstArg:
-  Enabled: true
-
 Metrics/BlockNesting:
   Max: 2
-
-Style/AlignHash:
-  EnforcedColonStyle: 'key'
-  EnforcedHashRocketStyle: 'key'
 
 Style/WordArray:
   Enabled: false

--- a/lib/fix_db_schema_conflicts/autocorrect_configuration.rb
+++ b/lib/fix_db_schema_conflicts/autocorrect_configuration.rb
@@ -1,0 +1,17 @@
+module FixDBSchemaConflicts
+  class AutocorrectConfiguration
+    def self.load
+      new.load
+    end
+
+    def load
+      at_least_rubocop_49? ? '.rubocop_schema.49.yml' : '.rubocop_schema.yml'
+    end
+
+    private
+
+    def at_least_rubocop_49?
+      Gem::Version.new('0.49.0') <= Gem.loaded_specs['rubocop'].version
+    end
+  end
+end

--- a/lib/fix_db_schema_conflicts/tasks/db.rake
+++ b/lib/fix_db_schema_conflicts/tasks/db.rake
@@ -1,15 +1,18 @@
 require 'shellwords'
+require_relative '../autocorrect_configuration'
 
 namespace :db do
   namespace :schema do
     task :dump do
       puts "Dumping database schema with fix-db-schema-conflicts gem"
+
       filename = ENV['SCHEMA'] || if defined? ActiveRecord::Tasks::DatabaseTasks
         File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, 'schema.rb')
       else
         "#{Rails.root}/db/schema.rb"
       end
-      rubocop_yml = File.expand_path('../../../../.rubocop_schema.yml', __FILE__)
+      autocorrect_config = FixDBSchemaConflicts::AutocorrectConfiguration.load
+      rubocop_yml = File.expand_path("../../../../#{autocorrect_config}", __FILE__)
       `bundle exec rubocop --auto-correct --config #{rubocop_yml} #{filename.shellescape}`
     end
   end

--- a/lib/fix_db_schema_conflicts/version.rb
+++ b/lib/fix_db_schema_conflicts/version.rb
@@ -1,3 +1,3 @@
 module FixDBSchemaConflicts
-  VERSION='3.0.1'
+  VERSION='3.0.2'
 end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -6,7 +6,7 @@ describe 'Fix DB Schema Conflicts' do
 
   it 'generates a sorted schema with no extra spacing' do
 
-    `cd spec/test-app && rm db/schema.rb && rake db:migrate`
+    `cd spec/test-app && rm -f db/schema.rb && rake db:migrate`
 
     generated_lines = File.readlines('spec/test-app/db/schema.rb')
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Fix DB Schema Conflicts' do
+RSpec.describe 'Fix DB Schema Conflicts' do
 
   let(:expected_lines) { reference_db_schema.lines }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,9 +40,9 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
@@ -53,7 +53,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  # config.example_status_persistence_file_path = "spec/examples.txt"
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
@@ -79,7 +79,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
@@ -92,5 +92,4 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end

--- a/spec/unit/autocorrect_configuration_spec.rb
+++ b/spec/unit/autocorrect_configuration_spec.rb
@@ -5,16 +5,19 @@ RSpec.describe FixDBSchemaConflicts::AutocorrectConfiguration do
   subject(:autocorrect_config) { described_class }
 
   it 'for versions up to 0.49.0' do
-    allow(Gem).to receive_message_chain(:loaded_specs, :[], :version)
-      .and_return(Gem::Version.new('0.38.0'))
+    installed_rubocop(version: '0.39.0')
 
     expect(autocorrect_config.load).to eq('.rubocop_schema.yml')
   end
 
   it 'for versions 0.49.0 and above' do
-    allow(Gem).to receive_message_chain(:loaded_specs, :[], :version)
-      .and_return(Gem::Version.new('0.49.0'))
+    installed_rubocop(version: '0.49.0')
 
     expect(autocorrect_config.load).to eq('.rubocop_schema.49.yml')
+  end
+
+  def installed_rubocop(version:)
+    allow(Gem).to receive_message_chain(:loaded_specs, :[], :version)
+      .and_return(Gem::Version.new(version))
   end
 end

--- a/spec/unit/autocorrect_configuration_spec.rb
+++ b/spec/unit/autocorrect_configuration_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'fix_db_schema_conflicts/autocorrect_configuration'
+
+RSpec.describe FixDBSchemaConflicts::AutocorrectConfiguration do
+  subject(:autocorrect_config) { described_class }
+
+  it 'for versions up to 0.49.0' do
+    allow(Gem).to receive_message_chain(:loaded_specs, :[], :version)
+      .and_return(Gem::Version.new('0.38.0'))
+
+    expect(autocorrect_config.load).to eq('.rubocop_schema.yml')
+  end
+
+  it 'for versions 0.49.0 and above' do
+    allow(Gem).to receive_message_chain(:loaded_specs, :[], :version)
+      .and_return(Gem::Version.new('0.49.0'))
+
+    expect(autocorrect_config.load).to eq('.rubocop_schema.49.yml')
+  end
+end


### PR DESCRIPTION
Some of the cops used to autocorrect `db/schema.rb` have been moved to another [department](https://github.com/bbatsov/rubocop/pull/4278) as of Rubocop `0.49.0`.

Add the `FixDBSchemaConflicts::AutocorrectConfiguration` class to choose the appropriate Rubocop autocorrect configuration:  `.rubocop_schema.yml` or `.rubocop_schema.49.yml`.