### PR TITLE
Support rubocop binstub

### DIFF
--- a/lib/fix_db_schema_conflicts/tasks/db.rake
+++ b/lib/fix_db_schema_conflicts/tasks/db.rake
@@ -12,8 +12,10 @@ namespace :db do
         "#{Rails.root}/db/schema.rb"
       end
       autocorrect_config = FixDBSchemaConflicts::AutocorrectConfiguration.load
+      rubocop_binary = "#{Rails.root}/bin/rubocop"
+      rubocop_binary = "bundle exec rubocop" unless File.exists?(rubocop_binary)
       rubocop_yml = File.expand_path("../../../../#{autocorrect_config}", __FILE__)
-      `bundle exec rubocop --auto-correct --config #{rubocop_yml} #{filename.shellescape}`
+      `#{rubocop_binary} --auto-correct --config #{rubocop_yml} #{filename.shellescape}`
     end
   end
 end


### PR DESCRIPTION
For performance reasons, this adds a preference for the `bin/rubocop` that might be installed on some projects to the default `bundle exec` behavior