### PR TITLE
Explicitly Disable Style/Encoding (support RuboCop >= 0.50.0)

### DIFF
--- a/.rubocop_schema.49.yml
+++ b/.rubocop_schema.49.yml
@@ -13,6 +13,9 @@ Layout/ExtraSpacing:
 Layout/SpaceBeforeFirstArg:
   Enabled: true
 
+Style/Encoding:
+  Enabled: false
+
 Style/NumericLiterals:
   Enabled: false
 


### PR DESCRIPTION
As of RuboCop v0.50.0, the [Style/Encoding cop is now enabled by default](https://github.com/bbatsov/rubocop/pull/4445) and configured to remove the encoding magic-comment. This will strip the comment from the top of `db/schema.rb`, deviating from the expected behavior.

Disabling this cop will ensure that `fix_db_schema_conflicts` will output consistently regardless of RuboCop version.

This change was tested locally using RuboCop `0.49.1`. `0.50.0`, and `0.50.1`.

**Before:**
```
$ bundle exec rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 34080
..F

Failures:

  1) Fix DB Schema Conflicts generates a sorted schema with no extra spacing
     Failure/Error: expect(generated).to eq(expected)
     
       expected: "# encoding: UTF-8\n"
            got: "\n"
     
       (compared using ==)
     
       Diff:
       @@ -1,2 +1 @@
       -# encoding: UTF-8
       
     # ./spec/integration/integration_spec.rb:16:in `block (3 levels) in <top (required)>'
     # ./spec/integration/integration_spec.rb:13:in `each'
     # ./spec/integration/integration_spec.rb:13:in `block (2 levels) in <top (required)>'

Finished in 3.56 seconds (files took 0.11922 seconds to load)
3 examples, 1 failure

Failed examples:

rspec ./spec/integration/integration_spec.rb:7 # Fix DB Schema Conflicts generates a sorted schema with no extra spacing

Randomized with seed 34080
```

**After:**
```
$ bundle exec rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 64151
...

Finished in 4.14 seconds (files took 0.16542 seconds to load)
3 examples, 0 failures

Randomized with seed 64151
```