### PR TITLE
Fix Error: The `Style/TrailingCommaInLiteral` cop no longer exists

### DIFF
--- a/.rubocop_schema.49.yml
+++ b/.rubocop_schema.49.yml
@@ -22,7 +22,16 @@ Metrics/BlockNesting:
 Style/WordArray:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/Encoding:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: 'comma'
 
 Style/TrailingCommaInArguments:


### PR DESCRIPTION
1. Disable Encoding and FrozenStringLiteralComment as it is enabled by default in newer versions of Rubocop

2. Fix Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in ../ruby/2.5.0/lib/ruby/gems/2.5.0/gems/fix-db-schema-conflicts-3.0.2/.rubocop_schema.49.yml, please update it)