### PR TITLE
Support rubocop 0.53.0

### DIFF
--- a/.rubocop_schema.53.yml
+++ b/.rubocop_schema.53.yml
@@ -1,0 +1,38 @@
+# Configuration for Rubocop >= 0.53.0
+
+Layout/AlignHash:
+  EnforcedColonStyle: 'key'
+  EnforcedHashRocketStyle: 'key'
+
+Layout/ExtraSpacing:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: false
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Style/NumericLiterals:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Max: 2
+
+Style/WordArray:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/HashSyntax:
+  EnforcedStyle: 'ruby19'
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/lib/fix_db_schema_conflicts/autocorrect_configuration.rb
+++ b/lib/fix_db_schema_conflicts/autocorrect_configuration.rb
@@ -5,13 +5,23 @@ module FixDBSchemaConflicts
     end
 
     def load
-      at_least_rubocop_49? ? '.rubocop_schema.49.yml' : '.rubocop_schema.yml'
+      if at_least_rubocop_53?
+        '.rubocop_schema.53.yml'
+      elsif at_least_rubocop_49?
+        '.rubocop_schema.49.yml'
+      else
+        '.rubocop_schema.yml'
+      end
     end
 
     private
 
     def at_least_rubocop_49?
       Gem::Version.new('0.49.0') <= Gem.loaded_specs['rubocop'].version
+    end
+
+    def at_least_rubocop_53?
+      Gem::Version.new('0.53.0') <= Gem.loaded_specs['rubocop'].version
     end
   end
 end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -20,7 +20,6 @@ end
 
 def reference_db_schema
   <<-RUBY
-# encoding: UTF-8
 
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to

--- a/spec/test-app/db/schema.rb
+++ b/spec/test-app/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to

--- a/spec/unit/autocorrect_configuration_spec.rb
+++ b/spec/unit/autocorrect_configuration_spec.rb
@@ -10,10 +10,16 @@ RSpec.describe FixDBSchemaConflicts::AutocorrectConfiguration do
     expect(autocorrect_config.load).to eq('.rubocop_schema.yml')
   end
 
-  it 'for versions 0.49.0 and above' do
+  it 'for versions 0.49.0 up to but not including 0.53.0' do
     installed_rubocop(version: '0.49.0')
 
     expect(autocorrect_config.load).to eq('.rubocop_schema.49.yml')
+  end
+
+  it 'for versions 0.53.0 and above' do
+    installed_rubocop(version: '0.53.0')
+
+    expect(autocorrect_config.load).to eq('.rubocop_schema.53.yml')
   end
 
   def installed_rubocop(version:)


### PR DESCRIPTION
This is a straightforward extension of the current scheme for handling different versions of `rubocop`: add another configuration file to handle the cop that was renamed as part of the `rubocop` `0.53.0` release.

This change works just fine for my situation. Looking at the _issues_ and _pull requests_ it most likely will not suit everyone's needs :)
