### PR TITLE
Fixed an awkward space in Readme#Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ And then execute:
 
 ## Older versions of Rubocop:
 
-If you wish to use a version of Rubocop `< 0.36.0` or below, use `gem 'fix-db-
-schema-conflicts', '~> 1.0.2'`
+If you wish to use a version of Rubocop `< 0.36.0` or below, use 
+`gem 'fix-db-schema-conflicts', '~> 1.0.2'`
 
 ## Older versions of Ruby:
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ auto-correct flag to ensure a consistent output format.
 ## Usage
 
 You don't have to do anything different. It should just work. Simply run `rake
-db:migrate` or `rake db:schema:dump` as you would before and `fix-db-schema-
-conflicts` will do the rest.
+db:migrate` or `rake db:schema:dump` as you would before and 
+`fix-db-schema-conflicts` will do the rest.
 
 ## Installation
 


### PR DESCRIPTION
A line break was causing an awkward space in `fix-db-schema- conflicts`.