### PR TITLE
Add support for rubocop >= 0.53.0

### DIFF
--- a/.rubocop_schema.53.yml
+++ b/.rubocop_schema.53.yml
@@ -1,0 +1,38 @@
+# Configuration for Rubocop >= 0.49.0
+
+Layout/AlignHash:
+  EnforcedColonStyle: 'key'
+  EnforcedHashRocketStyle: 'key'
+
+Layout/ExtraSpacing:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: false
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Style/NumericLiterals:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Max: 2
+
+Style/WordArray:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/HashSyntax:
+  EnforcedStyle: 'ruby19'
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/.rubocop_schema.53.yml
+++ b/.rubocop_schema.53.yml
@@ -1,4 +1,4 @@
-# Configuration for Rubocop >= 0.49.0
+# Configuration for Rubocop >= 0.53.0
 
 Layout/AlignHash:
   EnforcedColonStyle: 'key'

--- a/lib/fix_db_schema_conflicts/autocorrect_configuration.rb
+++ b/lib/fix_db_schema_conflicts/autocorrect_configuration.rb
@@ -5,13 +5,19 @@ module FixDBSchemaConflicts
     end
 
     def load
-      at_least_rubocop_49? ? '.rubocop_schema.49.yml' : '.rubocop_schema.yml'
+      if less_than_rubocop?(49)
+        '.rubocop_schema.yml'
+      elsif less_than_rubocop?(53)
+        '.rubocop_schema.49.yml'
+      else
+        '.rubocop_schema.53.yml'
+      end
     end
 
     private
 
-    def at_least_rubocop_49?
-      Gem::Version.new('0.49.0') <= Gem.loaded_specs['rubocop'].version
+    def less_than_rubocop?(ver)
+      Gem.loaded_specs['rubocop'].version < Gem::Version.new("0.#{ver}.0")
     end
   end
 end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -20,8 +20,6 @@ end
 
 def reference_db_schema
   <<-RUBY
-# encoding: UTF-8
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/spec/test-app/db/schema.rb
+++ b/spec/test-app/db/schema.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/spec/unit/autocorrect_configuration_spec.rb
+++ b/spec/unit/autocorrect_configuration_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe FixDBSchemaConflicts::AutocorrectConfiguration do
     expect(autocorrect_config.load).to eq('.rubocop_schema.49.yml')
   end
 
+  it 'for versions 0.53.0 and above' do
+    installed_rubocop(version: '0.53.0')
+
+    expect(autocorrect_config.load).to eq('.rubocop_schema.53.yml')
+  end
+
   def installed_rubocop(version:)
     allow(Gem).to receive_message_chain(:loaded_specs, :[], :version)
       .and_return(Gem::Version.new(version))


### PR DESCRIPTION
Updates trailing comma configuration to be compatible with rubocop >= 0.53.0 (and resolve deprecation warnings for `Style/TrailingCommaInLiteral`)