### PR TITLE
new schema for rubocop >= 0.53

### DIFF
--- a/.rubocop_schema.53.yml
+++ b/.rubocop_schema.53.yml
@@ -1,0 +1,38 @@
+# Configuration for Rubocop >= 0.53.0
+
+Layout/AlignHash:
+  EnforcedColonStyle: 'key'
+  EnforcedHashRocketStyle: 'key'
+
+Layout/ExtraSpacing:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: false
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Style/NumericLiterals:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Max: 2
+
+Style/WordArray:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/HashSyntax:
+  EnforcedStyle: 'ruby19'
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/lib/fix_db_schema_conflicts/autocorrect_configuration.rb
+++ b/lib/fix_db_schema_conflicts/autocorrect_configuration.rb
@@ -5,10 +5,20 @@ module FixDBSchemaConflicts
     end
 
     def load
-      at_least_rubocop_49? ? '.rubocop_schema.49.yml' : '.rubocop_schema.yml'
+      if at_least_rubocop_53?
+        '.rubocop_schema.53.yml'
+      elsif at_least_rubocop_49?
+        '.rubocop_schema.49.yml'
+      else
+        '.rubocop_schema.yml'
+      end
     end
 
     private
+
+    def at_least_rubocop_53?
+      Gem::Version.new('0.53.0') <= Gem.loaded_specs['rubocop'].version
+    end
 
     def at_least_rubocop_49?
       Gem::Version.new('0.49.0') <= Gem.loaded_specs['rubocop'].version


### PR DESCRIPTION
Support rubocop >= 0.53 which deprecated `Style/TrailingCommaInLiteral` in favor of `Style/TrailingCommaInArrayLiteral` and `Style/TrailingCommaInHashLiteral`

https://github.com/rubocop-hq/rubocop/pull/5307