### PR TITLE
chore(pkg): keep useful files only

### DIFF
--- a/fix-db-schema-conflicts.gemspec
+++ b/fix-db-schema-conflicts.gemspec
@@ -13,10 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/jakeonrails/fix-db-schema-conflicts'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
+  spec.files         = Dir['LICENSE.txt', 'README.md', 'lib/**/*']
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 11.2.0'


### PR DESCRIPTION
This PR may also fix errors from RuboCop, depending on the versions, such as:
> Dumping database schema with fix-db-schema-conflicts gem
> Error: The `Layout/AlignHash` cop has been renamed to `Layout/HashAlignment`.
> (obsolete configuration found in /Users/cyril/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/fix-db-schema-conflicts-3.0.3/.rubocop_schema.53.yml, please update it)