### PR TITLE
Fix Rubocop Layout/HashAlignment warning

### DIFF
--- a/.rubocop_schema.77.yml
+++ b/.rubocop_schema.77.yml
@@ -1,0 +1,38 @@
+# Configuration for Rubocop >= 0.77.0
+
+Layout/ExtraSpacing:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: false
+
+Layout/HashAlignment:
+  EnforcedColonStyle: 'key'
+  EnforcedHashRocketStyle: 'key'
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Style/NumericLiterals:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Max: 2
+
+Style/WordArray:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/HashSyntax:
+  EnforcedStyle: 'ruby19'
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/.rubocop_schema.77.yml
+++ b/.rubocop_schema.77.yml
@@ -10,6 +10,9 @@ Layout/HashAlignment:
   EnforcedColonStyle: 'key'
   EnforcedHashRocketStyle: 'key'
 
+Layout/LineLength:
+  Enabled: false
+
 Layout/SpaceBeforeFirstArg:
   Enabled: true
 

--- a/lib/fix_db_schema_conflicts/autocorrect_configuration.rb
+++ b/lib/fix_db_schema_conflicts/autocorrect_configuration.rb
@@ -9,8 +9,10 @@ module FixDBSchemaConflicts
         '.rubocop_schema.yml'
       elsif less_than_rubocop?(53)
         '.rubocop_schema.49.yml'
-      else
+      elsif less_than_rubocop?(77)
         '.rubocop_schema.53.yml'
+      else
+        '.rubocop_schema.77.yml'
       end
     end
 

--- a/spec/unit/autocorrect_configuration_spec.rb
+++ b/spec/unit/autocorrect_configuration_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe FixDBSchemaConflicts::AutocorrectConfiguration do
     expect(autocorrect_config.load).to eq('.rubocop_schema.53.yml')
   end
 
+  it 'for versions 0.77.0 and above' do
+    installed_rubocop(version: '0.77.0')
+
+    expect(autocorrect_config.load).to eq('.rubocop_schema.77.yml')
+  end
+
   def installed_rubocop(version:)
     allow(Gem).to receive_message_chain(:loaded_specs, :[], :version)
       .and_return(Gem::Version.new(version))


### PR DESCRIPTION
The Rubocop `Layout/AlignHash` rule was renamed to `Layout/HashAlignment`. This PR adds another >= Rubocop config file to prevent displaying a warning every time the schema is dumped.