### PR TITLE
Fix: use the correct layout cop for rubocop

### DIFF
--- a/.rubocop_schema.53.yml
+++ b/.rubocop_schema.53.yml
@@ -1,6 +1,6 @@
 # Configuration for Rubocop >= 0.53.0
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedColonStyle: 'key'
   EnforcedHashRocketStyle: 'key'
 


### PR DESCRIPTION
A fix to the rubocop warning for issue #39 