### PR TITLE
Allow Ruby 3 installs

### DIFF
--- a/fix-db-schema-conflicts.gemspec
+++ b/fix-db-schema-conflicts.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '>= 0.38.0'
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.0.0'
 end

--- a/fix-db-schema-conflicts.gemspec
+++ b/fix-db-schema-conflicts.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '>= 0.38.0'
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.0.0', '< 4'
 end


### PR DESCRIPTION
Hello 👋 ,

Ruby 3 was released on Dec 2020 https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

While trying to upgrade a personal project I got the following error:

```
fix-db-schema-conflicts-3.0.3 requires ruby version ~> 2.0, which is incompatible with the current version, ruby 3.0.2p107
```

It's unlikely that fix-db-schema doesn't work with Ruby 3 given is a compatible release:

> Ruby3.0 is a milestone. The language is evolved, keeping compatibility. But it’s not the end. Ruby will keep progressing, and become even greater. Stay tuned! — Matz

Cheers,
