### PR TITLE
Use --autocorrect flag

### DIFF
--- a/lib/fix_db_schema_conflicts/tasks/db.rake
+++ b/lib/fix_db_schema_conflicts/tasks/db.rake
@@ -13,7 +13,7 @@ namespace :db do
       end
       autocorrect_config = FixDBSchemaConflicts::AutocorrectConfiguration.load
       rubocop_yml = File.expand_path("../../../../#{autocorrect_config}", __FILE__)
-      `bundle exec rubocop --auto-correct --config #{rubocop_yml} #{filename.shellescape}`
+      `bundle exec rubocop --autocorrect --config #{rubocop_yml} #{filename.shellescape}`
     end
   end
 end


### PR DESCRIPTION
Rubocop has deprecated the `--auto-correct` flag in favour of the `--autocorrect` flag.

```
Dumping database schema with fix-db-schema-conflicts gem
--auto-correct is deprecated; use --autocorrect instead
```