### PR TITLE
sort table columns by type, as hinted by name conventions

### DIFF
--- a/lib/fix_db_schema_conflicts/schema_dumper.rb
+++ b/lib/fix_db_schema_conflicts/schema_dumper.rb
@@ -12,11 +12,30 @@ module FixDBSchemaConflicts
       end
 
       def indexes(table)
-        __getobj__.indexes(table).sort_by(&:name)
+        indexes_string_sort(table)
+        # __getobj__.indexes(table).sort_by(&:name)
       end
 
       def foreign_keys(table)
         __getobj__.indexes(table).sort_by(&:name)
+      end
+
+      def indexes_string_sort(table)
+        cols = __getobj__.indexes(table)
+        cols.reduce({ids:[],datetimes:[],other:[]}) do |h,col|
+          case col.name
+          when /_id$"/
+            h[:ids] << col
+          when /_at$"/
+            h[:datetimes] << col
+          else
+            h[:other] << col
+          end
+          h
+        end.tap {|h| h[:ids      ] = h[:ids      ].sort{|a,b| a.name <=> b.name }}
+        .tap    {|h| h[:datetimes] = h[:datetimes].sort{|a,b| a.name <=> b.name }}
+        .tap    {|h| h[:other    ] = h[:other    ].sort{|a,b| a.name <=> b.name }}
+        .values.flatten
       end
     end
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -43,6 +43,8 @@ ActiveRecord::Schema.define(version: 20160322223258) do
     t.string "state"
     t.datetime "updated_at", null: false
     t.string "zip"
+    t.bigint "entity_registry_id"
+    t.integer "corporation_type_id"
   end
 
   add_index "companies", ["city"], name: "index_companies_on_city"


### PR DESCRIPTION
It's common that IDs are put at the top of a table's schema / DDL.  Datetime fields (`*_at`) are often grouped, commonly after all other columns.  The rest of the columns are sandwiched between them. 

This PRs offers similar sorting technique.

- group table columns by IDs, _at dates, and the rest
- order IDs first, other non-dates, then the _at fields
- each group sorted alphabetically

I wasn't able to get the tests to run.  Welcome feedback on how to write better tests