### PR TITLE
Use proper autocorrect arg based on rubocop version

### DIFF
--- a/lib/fix_db_schema_conflicts/tasks/db.rake
+++ b/lib/fix_db_schema_conflicts/tasks/db.rake
@@ -13,14 +13,13 @@ namespace :db do
       end
       autocorrect_config = FixDBSchemaConflicts::AutocorrectConfiguration.load
       rubocop_yml = File.expand_path("../../../../#{autocorrect_config}", __FILE__)
+      auto_correct_arg = if Gem.loaded_specs['rubocop'].version >= Gem::Version.new('1.30')
+        'autocorrect'
+      else
+        'auto-correct'
+      end
+
       `bundle exec rubocop --#{auto_correct_arg} --config #{rubocop_yml} #{filename.shellescape}`
-    end
-
-    private
-
-    def auto_correct_arg
-      return 'autocorrect' if Gem.loaded_specs['rubocop'].version >= Gem::Version.new('1.30')
-      'auto-correct'
     end
   end
 end

--- a/lib/fix_db_schema_conflicts/tasks/db.rake
+++ b/lib/fix_db_schema_conflicts/tasks/db.rake
@@ -13,7 +13,14 @@ namespace :db do
       end
       autocorrect_config = FixDBSchemaConflicts::AutocorrectConfiguration.load
       rubocop_yml = File.expand_path("../../../../#{autocorrect_config}", __FILE__)
-      `bundle exec rubocop --auto-correct --config #{rubocop_yml} #{filename.shellescape}`
+      `bundle exec rubocop --#{auto_correct_arg} --config #{rubocop_yml} #{filename.shellescape}`
+    end
+
+    private
+
+    def auto_correct_arg
+      return 'autocorrect' if Gem.loaded_specs['rubocop'].version >= Gem::Version.new('1.30')
+      'auto-correct'
     end
   end
 end


### PR DESCRIPTION
Addressing the comment from this [PR](https://github.com/jakeonrails/fix-db-schema-conflicts/pull/50) about version < 1.30