### PR TITLE
Unlock Ruby version constraint (support Ruby 4+)

### DIFF
--- a/.rubocop_schema.77.yml
+++ b/.rubocop_schema.77.yml
@@ -1,5 +1,8 @@
 # Configuration for Rubocop >= 0.77.0
 
+AllCops:
+  NewCops: enable
+
 Layout/ExtraSpacing:
   # When true, allows most uses of extra spacing if the intent is to align
   # things with the previous or next line, not counting empty lines or comment

--- a/fix-db-schema-conflicts.gemspec
+++ b/fix-db-schema-conflicts.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '>= 0.38.0'
 
-  spec.required_ruby_version = '>= 2.0.0', '< 4'
+  spec.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
Remove < 4 upper bound from `required_ruby_version` in gemspec to support Ruby 4+